### PR TITLE
Add support for pellet harvesters (i.e. the Premos 5000 from Straw Harvest)

### DIFF
--- a/TipAnywhere.lua
+++ b/TipAnywhere.lua
@@ -9,6 +9,7 @@ TipAnywhere.tip = true
 TipAnywhere.shovel = true
 TipAnywhere.workAreas = {
 	['BALER'] = true,
+	['PELLETIZER'] = true,
 	['COMBINECHOPPER'] = false,
 	['COMBINESWATH'] = false,
 	['CULTIVATOR'] = false,
@@ -33,10 +34,11 @@ TipAnywhere.workAreas = {
 }
 TipAnywhere.menuItems = {
 	[1] = 'BALER',
-	[2] = 'FORAGEWAGON',
-	[3] = 'TEDDER',
-	[4] = 'WINDROWER',
-	[5] = 'MOWER'
+	[2] = 'PELLETIZER',
+	[3] = 'FORAGEWAGON',
+	[4] = 'TEDDER',
+	[5] = 'WINDROWER',
+	[6] = 'MOWER'
 }
 
 TipAnywhere.OPTION = {

--- a/language/l10n_cs.xml
+++ b/language/l10n_cs.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_ct.xml
+++ b/language/l10n_ct.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_cz.xml
+++ b/language/l10n_cz.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_da.xml
+++ b/language/l10n_da.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_ea.xml
+++ b/language/l10n_ea.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_en.xml
+++ b/language/l10n_en.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_es.xml
+++ b/language/l10n_es.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_fc.xml
+++ b/language/l10n_fc.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_fi.xml
+++ b/language/l10n_fi.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_hu.xml
+++ b/language/l10n_hu.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_it.xml
+++ b/language/l10n_it.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_jp.xml
+++ b/language/l10n_jp.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_kr.xml
+++ b/language/l10n_kr.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_nl.xml
+++ b/language/l10n_nl.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_no.xml
+++ b/language/l10n_no.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_pl.xml
+++ b/language/l10n_pl.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_pt.xml
+++ b/language/l10n_pt.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_ro.xml
+++ b/language/l10n_ro.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_sl.xml
+++ b/language/l10n_sl.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_sv.xml
+++ b/language/l10n_sv.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>

--- a/language/l10n_tr.xml
+++ b/language/l10n_tr.xml
@@ -5,6 +5,9 @@
 		
 		<text name="setting_tipanywhere_BALER" text="Baling"/>
 		<text name="tooltip_tipanywhere_BALER" text="Allow balers to operate on unowned land."/>
+
+		<text name="setting_tipanywhere_PELLETIZER" text="Pellet Harvesting"/>
+		<text name="tooltip_tipanywhere_PELLETIZER" text="Allow pellet harvesters to operate on unowned land."/>
 		
 		<text name="setting_tipanywhere_COMBINECHOPPER" text="Harvesting"/>
 		<text name="tooltip_tipanywhere_COMBINECHOPPER" text="Allow combine harvesters to operate on unowned land."/>


### PR DESCRIPTION
A few notes:

- I added it right after the baler category since the machine looks and operates most like a baler.
- I used the term Pellet Harvester rather than Pelletizer or Pellet Press since this is  the "typedesc" string for the premos.
- I didn't attempt to add it to any non-english l10n files since I don't speak the relevant languages.

I originally only modified this for my own use, but since the mod is on github I thought I might as well offer this as a contribution. 